### PR TITLE
Create github action to upload repo zipped to s3 sample apps bucket

### DIFF
--- a/.github/workflows/s3-upload-sample-app.yml
+++ b/.github/workflows/s3-upload-sample-app.yml
@@ -1,0 +1,30 @@
+name: Zip and upload to s3 bucket
+
+on:
+  push:
+    branches:
+      - main
+      - staging
+jobs:
+  zip-and-upload:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Zip the repository
+      run: |
+        zip -r demo-react.zip .
+    - name: Upload to s3
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-west-2
+    - name: Upload to S3
+      if: github.ref == 'refs/heads/main'
+      run: aws s3 cp demo-react.zip s3://prod.slashauth.sample-apps
+    - name: Upload to S3
+      if: github.ref == 'refs/heads/staging'
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+      run: aws s3 cp demo-react.zip s3://staging.slashauth.sample-apps


### PR DESCRIPTION
## Refs

- **Issue**: resolves [SLAS-684](https://getdebrief.atlassian.net/browse/SLAS-684)

## What?

Setup continuous deployment of demo-react to work with Sample App feature

## Why?

Sample App feature depends on demo-react. We don't want to be manually updating the zipped repo version in s3.

## Warning:
- [ ] Terraform changes should be applied to be able to access s3 buckets from github actions
- [ ] AWS secrets need to be added to github actions
